### PR TITLE
Fix caching manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Minipack
 
-Forked from [nikushi/minipack](https://github.com/nikushi/minipack) until [#42](https://github.com/nikushi/minipack/pull/42) lands. Once it's merged we can delete this fork.
+Forked from [nikushi/minipack](https://github.com/nikushi/minipack) until [#42](https://github.com/nikushi/minipack/pull/42) and [#46](https://github.com/nikushi/minipack/pull/46) land. Once they're merged we can delete this fork.
+
+Note for future readers: Minipack (and especially the parts of Minipack we actually use) is really small, basically just a ruby api for reading a json file and creating some html tags. Upstream seems abandoned, so for any dramatic changes it might be easier to just fold this code into platform.


### PR DESCRIPTION
RE: [this issue](https://github.com/nikushi/minipack/issues/45). TL;DR: manifest caching is essentially broken.

This was causing performance issues, discussed more [here](https://github.com/Appboy/platform/pull/68042). In practice this isn't a *huge* deal (+10ms on each `dashboard.html.erb` page load), but it just seems wild to re-parse the 354kb manifest _multiple times_ every time `dashboard.html.erb` gets rendered. Fixing this also unlocks using the manifest for referencing other frontend assets.

One of the assumptions backing this change is that fixing caching won't break anything. The question is: do we expect the `manifest.json` file to change at runtime, or is it fixed for the duration of a deployment? I imagine that _today_ it's probably baked in to the image, but in the future (when we separate frontend/backend deployments) it may need to update dynamically. IMO that means that this fix is worth doing now, and we can cross that bridge when we get there.

Side note, but minipack (and esp the parts of minipack we actually use) is _really_ small, basically just a ruby api for reading a json file and creating some tags. Upstream is abandoned, for any dramatic changes it might be easier to just fold this code into platform.

We can merge and test in a PCE before tagging + updating the version used in platform.

Note that this won't affect development, as "caching" is disabled.